### PR TITLE
Adding a boilerplate for shsg 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+public/*
+content/*
+themes/*

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ssg.sh
+# shsg
 A static site generator written in POSIX shell.
 
 ## Why?

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# ssg.sh
+A static site generator written in POSIX shell.
+
+## Why?
+Because sometimes, you just want a nice and simple website, 
+without having to set up Jekyll or Hugo or install 40 
+million different packages. Here is a simple static site 
+generator that will quite literally work on _anything_ that 
+supports POSIX shell and has anything resembling standard
+UNIX core utilities. If all you want is a simple website,
+what's not to like?
+

--- a/shsg
+++ b/shsg
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# shsg - shell site generator
+#
+# A simple static site generator using pure POSIX sh and basic UNIX coreutils.
+#
+# - The themes are located in ./themes
+# - The pages for the website are located in ./content
+# - The finished public website is located at ./public
+
+usage() {
+    >&2 echo "\nUsage: ./ssg.sh [OPTION] [THEME] ...
+\t-b\tbuild the site into ./public using [THEME]
+\t-c\tclean up current site
+\t-h\tprint this help message
+"
+}
+
+case $1 in
+    -b) ./source/build ;;
+    -c) ./source/clean ;;
+    *) usage ;;
+esac

--- a/shsg
+++ b/shsg
@@ -10,7 +10,7 @@
 # - The scripts responsible for this script is at ./source
 
 case $1 in
-    -b) ./source/build ;;
-    -c) ./source/clean ;;
-    *) ./source/usage $1 ;;
+    -b) source/build $2 ;;
+    -c) source/clean ;;
+    *) source/usage $1 ;;
 esac

--- a/shsg
+++ b/shsg
@@ -7,17 +7,10 @@
 # - The themes are located in ./themes
 # - The pages for the website are located in ./content
 # - The finished public website is located at ./public
-
-usage() {
-    >&2 echo "\nUsage: ./ssg.sh [OPTION] [THEME] ...
-\t-b\tbuild the site into ./public using [THEME]
-\t-c\tclean up current site
-\t-h\tprint this help message
-"
-}
+# - The scripts responsible for this script is at ./source
 
 case $1 in
     -b) ./source/build ;;
     -c) ./source/clean ;;
-    *) usage ;;
+    *) ./source/usage $1 ;;
 esac

--- a/source/build
+++ b/source/build
@@ -1,9 +1,10 @@
 #!/bin/sh
 
-# shsg/source/build - script responsible for building
+# ./source/build - script responsible for building
 #
 # todo:
 # 
 
-echo hi
+[ -z $1 ] && usage && exit
 
+echo poop

--- a/source/build
+++ b/source/build
@@ -1,10 +1,64 @@
 #!/bin/sh
 
-# ./source/build - script responsible for building
+# source/build - handles the preliminary tasks before building
 #
-# todo:
+# Todo:
 # 
 
-[ -z $1 ] && usage && exit
+[ -z $1 ] && source/usage && exit
 
-echo poop
+# Import the parser function
+. source/parser
+
+if [ -d "themes/$1" ]
+then 
+    source/clean
+
+    echo "--- Using theme $1"
+
+    echo "==> Building site into public..."
+    mkdir -v public
+
+    # Copy theme css over
+    cp -rv "themes/$1/styles" "public/styles"
+
+    # Process every markdown file, but also don't process dotfiles
+    for f in $(find content | grep -E 'content\/[^\.].*\.md$')
+    do
+        # Don't process directories
+        [ -d $f ] && continue
+
+        echo "--- Processing $f..."
+
+        # Caching first line for later use
+        f_1l=$(head -n 1 $f)
+
+        # If type line does not exist
+        if [ -z "$(printf "$f_1l" | grep '<!--.*-->')" ] 
+        then
+            f_type='generic'
+            f_1l='' # read first line for input
+        else
+            f_type=$(echo "$f_1l" | sed -E 's/<!--//; s/-->//; s/\s//g')
+            # if type is not defined, default to generic
+            [ -z "$f_type" ] && f_type='generic'
+        fi
+
+        f_type_loc="themes/$1/filetype/$f_type"
+        if [ -d "$f_type_loc" ]
+        then
+            echo "--- $f has type $f_type."
+        else
+            echo "==> Error: $f has undefined type $f_type."
+            continue
+        fi
+
+        f_final_dest=$(echo "$f" | sed -E 's/^content/public/; s/md$/html/')
+
+        parser
+
+    done
+    echo "==> Build finished."
+else
+    echo "==> Error: theme $1 not found." && exit
+fi

--- a/source/build
+++ b/source/build
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# shsg/source/build - script responsible for building
+#
+# todo:
+# 
+
+echo hi
+

--- a/source/clean
+++ b/source/clean
@@ -1,5 +1,9 @@
 #!/bin/sh
 
-# ./source/build - script responsible for cleaning
+# source/clean - "macro" for cleaning
+#
+# todo: Do I really need this as a separate file?
+#       Currently this is here because I'm lazy
 
-echo bye
+
+[ -d './public' ] && printf "==> Cleaning up...\n" && rm -vr ./public

--- a/source/clean
+++ b/source/clean
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-# shsg/source/build - script responsible for cleaning
+# ./source/build - script responsible for cleaning
 
 echo bye

--- a/source/clean
+++ b/source/clean
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+# shsg/source/build - script responsible for cleaning
+
+echo bye

--- a/source/parser
+++ b/source/parser
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+# source/parser - parses and stitches the markdown file
+
+parser() {
+    # Copy the header over to start the file
+    mkdir -pv ${f_final_dest%/*} # removes filename
+    cp -v "$f_type_loc/template_header" "$f_final_dest"
+
+    while IFS= read -r l || [ -n "$l" ]
+    do
+        [ -z "$l" ] && continue
+        # Discard first line in the file if it's a type line
+        [ "$l" = "$f_1l" ] && continue
+    
+        # echo "$l"
+    
+        # # h* of any number
+        # l_test="$(echo $l | grep -o '^#*')"
+        # [ -n "$l_test" ] && handle_h && continue
+        # 
+        # # Custom elements
+        # l_test="$(echo $l | grep -o '^\$\w*:::..')"
+        # [ -n "$l_test" ] && handle_special && continue
+    
+        # # No type, it's a p
+        # handle_p
+    done < "$f"
+
+    cat "$f_type_loc/template_footer" >> "$f_final_dest"
+}

--- a/source/usage
+++ b/source/usage
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+[ -n "$1" ] && printf "Invalid option: $1\n"
+
+printf "Usage: ./shsg [OPTION] [THEME] ...
+Options:
+  -b    build the site into ./public using [THEME]
+  -c    clean up current site
+  -h    print this help message
+"


### PR DESCRIPTION
Implemented a boilerplate for shsg to work on. 
- Shsg now stitches themes together, but ignores the content of the file
- For every kind of syntax in markdown, simply write a new function in `source` and run the current line through said function
- A function for handling raw text will be needed for all functions